### PR TITLE
Chore/change alias method chain to alias method

### DIFF
--- a/lib/multi_fetch_fragments.rb
+++ b/lib/multi_fetch_fragments.rb
@@ -2,7 +2,8 @@ module MultiFetchFragments
   extend ActiveSupport::Concern
 
   included do
-    alias_method_chain :render_collection, :multi_fetch_cache
+    alias_method :render_collection_without_multi_fetch_cache, :render_collection
+    alias_method :render_collection, :render_collection_with_multi_fetch_cache
   end
 
   private
@@ -83,7 +84,7 @@ module MultiFetchFragments
       ActionController::Base.perform_caching && cache_option
     end
 
-    # from Rails fragment_cache_key in ActionController::Caching::Fragments. Adding it here since it's tucked inside an instance method on the controller, and 
+    # from Rails fragment_cache_key in ActionController::Caching::Fragments. Adding it here since it's tucked inside an instance method on the controller, and
     # it's utility could be used in a view without a controller
     def fragment_cache_key(key)
       ActiveSupport::Cache.expand_cache_key(key.is_a?(Hash) ? url_for(key).split("://").last : key, :views)

--- a/spec/multi_fetch_fragments_spec.rb
+++ b/spec/multi_fetch_fragments_spec.rb
@@ -10,7 +10,7 @@ describe MultiFetchFragments do
 
   it "works for passing in a custom key" do
     cache_mock = mock()
-    RAILS_CACHE = cache_mock
+    Rails.cache = cache_mock
     MultiFetchFragments::Railtie.run_initializers
 
     controller = ActionController::Base.new
@@ -18,7 +18,7 @@ describe MultiFetchFragments do
 
     customer = Customer.new("david")
     key = controller.fragment_cache_key([customer, 'key'])
-    
+
     cache_mock.should_receive(:read_multi).with(key).and_return({key => 'Hello'})
 
     view.render(:partial => "views/customer", :collection => [ customer ], :cache => Proc.new{ |item| [item, 'key']}).should == "Hello"


### PR DESCRIPTION
Greening specs and replace the alias_method_change for alias_method to work with Rails 5